### PR TITLE
rewrite completion provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
 inoremap <expr> <cr> pumvisible() ? "\<C-y>\<cr>" : "\<cr>"
 ```
 
+### Force refresh completion
+
+```vim
+imap <c-space> <Plug>(asyncomplete_force_refresh)
+```
+
 #### Preview Window
 
 To disable preview window:
@@ -92,7 +98,16 @@ The above sample shows synchronous completion. If you would like to make it asyn
 call timer_start(2000, {timer-> asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches)})
 ```
 
-As a source author you do not have to worry about synchronization issues in case the server returns the async completion after the user has typed more characters. asyncomplete.vim uses partial caching as well as ignores if the context changes when calling `asyncomplete#complete`. This is one of the core reason why the original context must be passed when calling `asyncomplete#complete`.
+If you are returning incomplete results and would like to trigger completion on the next keypress pass `1` as the fifth parameter to `asyncomplete#complete`
+which signifies the result is incomplete.
+
+```vim
+call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches, 1)
+```
+
+As a source author you do not have to worry about synchronization issues in case the server returns the async completion after the user has typed more
+characters. asyncomplete.vim uses partial caching as well as ignores if the context changes when calling `asyncomplete#complete`.
+This is one of the core reason why the original context must be passed when calling `asyncomplete#complete`.
 
 ### Credits
 All the credit goes to the following projects

--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -1,10 +1,13 @@
 let s:sources = {}
-" let s:change_timer = -1
-" let s:last_tick = ''
-" let s:last_matches = []
-" let s:has_popped_up = 0
-" let s:complete_timer_ctx = {}
+let s:change_timer = -1
+let s:last_tick = ''
+let s:has_popped_up = 0
+let s:complete_timer_ctx = {}
 let s:already_setup = 0
+
+function! s:log(...) abort
+    call writefile([json_encode(a:000)], expand('~/Desktop/asyncomplete.log'), 'a')
+endfunction
 
 " do nothing, place it here only to avoid the message
 autocmd User asyncomplete_setup silent
@@ -18,10 +21,14 @@ function! asyncomplete#enable_for_buffer() abort
     let b:asyncomplete_enable = 1
     augroup ayncomplete
         autocmd! * <buffer>
-        " autocmd InsertEnter <buffer> call s:python_cm_insert_enter()
-        " autocmd InsertEnter <buffer> call s:python_cm_insert_leave()
-        " autocmd InsertEnter <buffer> call s:change_tick_start()
-        " autocmd InsertLeave <buffer> call s:change_tick_stop()
+        autocmd InsertEnter <buffer> call s:python_cm_insert_enter()
+        autocmd InsertEnter <buffer> call s:change_tick_start()
+        autocmd InsertLeave <buffer> call s:change_tick_stop()
+        " working together with timer, the timer is for detecting changes
+		" popup menu is visible. TextChangedI will not be triggered when popup
+		" menu is visible, but TextChangedI is more efficient and faster than
+		" timer when popup menu is not visible.
+        autocmd TextChangedI <buffer> call s:check_changes()
     augroup END
 endfunction
 
@@ -56,23 +63,19 @@ function! asyncomplete#unregister_source(name) abort
     endtry
 endfunction
 
-function! asyncomplete#complete(src, ctx, startcol, matches) abort
-"     let l:name = a:src
+function! asyncomplete#complete(name, ctx, startcol, matches, ...) abort
+    let l:refresh = 0
+    if len(a:000) > 0
+        let l:refresh = a:1
+    endif
 
-"     if get(b:, 'asyncomplete_enable', 0) == 0
-"         return 2
-"     endif
+    " ignore the request if context has changed
+	if asyncomplete#context_changed(a:ctx)
+        call s:python_cm_complete(a:name, a:ctx, a:startcol, a:matches, l:refresh, 1)
+        return 1
+    endif
 
-"     " ignore the request if context has changed
-"     if  (a:ctx != asyncomplete#context()) || (mode() != 'i')
-"         return 1
-"     endif
-
-"     if !has_key(s:sources, l:name)
-"         return 3
-"     endif
-
-"     call s:python_cm_complete(s:sources, l:name, a:ctx, a:startcol, a:matches)
+    call s:python_cm_complete(a:name, a:ctx, a:startcol, a:matches, l:refresh, 0)
 endfunction
 
 function! asyncomplete#context() abort
@@ -97,205 +100,218 @@ function! asyncomplete#context_changed(ctx)
 	return getcurpos() != a:ctx['curpos']
 endfunction
 
-" function! s:python_cm_insert_enter() abort
-"     let s:matches = {}
-" endfunction
+function! s:python_cm_insert_enter() abort
+    let s:matches = {}
+endfunction
 
 " function! s:python_cm_insert_leave() abort
 " endfunction
 
-" function! s:change_tick_start() abort
-"     if s:change_timer != -1
-"         return
-"     endif
-"     let s:last_tick = s:change_tick()
-"     " changes every 30ms, which is 0.03s, it should be fast enough
-"     let s:change_timer = timer_start(30, function('s:check_changes'), { 'repeat': -1 })
-"     call s:on_changed()
-" endfunction
+function! s:change_tick_start() abort
+    if s:change_timer != -1
+        return
+    endif
+    let s:last_tick = s:change_tick()
+    " changes every 30ms, which is 0.03s, it should be fast enough
+    let s:change_timer = timer_start(30, function('s:check_changes'), { 'repeat': -1 })
+    call s:on_changed()
+endfunction
 
-" function! s:change_tick_stop() abort
-"     if s:change_timer == -1
-"         return
-"     endif
-"     call timer_stop(s:change_timer)
-"     let s:last_tick = ''
-"     let s:change_timer = -1
-" endfunction
+function! s:change_tick_stop() abort
+    if s:change_timer == -1
+        return
+    endif
+    call timer_stop(s:change_timer)
+    let s:last_tick = ''
+    let s:change_timer = -1
+endfunction
 
-" function! s:on_changed() abort
-"     if get(b:, 'asyncomplete_enable', 0) == 0
-"         return
-"     endif
+function! s:on_changed() abort
+    if get(b:, 'asyncomplete_enable', 0) == 0 || mode() != 'i' || &paste != 0
+        return
+    endif
 
-"     if exists('s:complete_timer')
-"         call timer_stop(s:complete_timer)
-"         unlet s:complete_timer
-"     endif
+    if exists('s:complete_timer')
+        call timer_stop(s:complete_timer)
+        unlet s:complete_timer
+    endif
 
-"     let l:ctx = asyncomplete#context()
+    let l:ctx = asyncomplete#context()
 
-"     call s:python_cm_refresh(s:sources, l:ctx)
-" endfunction
+    call s:python_cm_refresh(l:ctx, 0)
+endfunction
 
-" function! s:check_changes(timer) abort
-"     let l:tick = s:change_tick()
-"     if l:tick != s:last_tick
-"         let s:last_tick = l:tick
-"         if mode()=='i' && (&paste==0)
-"             " only in insert non paste mode
-"             call s:on_changed()
-"         endif
-"     endif
-" endfunction
+function! s:check_changes(...) abort
+    let l:tick = s:change_tick()
+    if l:tick != s:last_tick
+        let s:last_tick = l:tick
+        call s:on_changed()
+    endif
+endfunction
 
-" function! s:change_tick() abort
-"     return [b:changedtick, getcurpos()]
-" endfunction
+function! s:change_tick() abort
+    return [b:changedtick, getcurpos()]
+endfunction
 
-" function! s:python_cm_complete(srcs, name, ctx, startcol, matches) abort
-"     let s:sources = a:srcs
+function! s:python_cm_complete(name, ctx, startcol, matches, refresh, outdated) abort
+    if (a:outdated)
+        " TODO: ignore outdated for now
+        return
+    endif
 
-"     if !has_key(s:matches, a:name)
-"         let s:matches[a:name] = {}
-"     endif
-"     if empty(a:matches)
-"         unlet s:matches[a:name]
-"     else
-"         let s:matches[a:name]['startcol'] = a:startcol
-"         let s:matches[a:name]['matches'] = a:matches
-"     endif
+    call s:log(a:name, a:ctx, a:startcol, len(a:matches))
 
-"     if s:has_popped_up == 1
-"         call s:python_refresh_completions(a:ctx)
-"     endif
-" endfunction
+    if !has_key(s:matches, a:name)
+        let s:matches[a:name] = {}
+    endif
+    if empty(a:matches)
+        unlet s:matches[a:name]
+    else
+        let s:matches[a:name]['startcol'] = a:startcol
+        let s:matches[a:name]['matches'] = a:matches
+        let s:matches[a:name]['refresh'] = a:refresh
+    endif
 
-" function! s:python_cm_complete_timeout(srcs, ctx) abort
-"     call s:python_refresh_completions(a:ctx)
-"     let s:has_popped_up = 1
-" endfunction
+    if s:has_popped_up == 1
+        call s:python_refresh_completions(asyncomplete#context())
+    endif
+endfunction
 
-" function! s:python_cm_refresh(srcs, ctx) abort
-"     let s:sources = a:srcs
-"     let s:has_popped_up = 0
-"     let l:typed = a:ctx['typed']
+function! s:python_cm_complete_timeout(srcs, ctx) abort
+    if !s:has_popped_up
+        call s:python_refresh_completions(a:ctx)
+        let s:has_popped_up = 1
+    endif
+endfunction
 
-"     " simple complete done
-"     if empty(l:typed)
-"         let s:matches = {}
-"     elseif !empty(matchstr(l:typed[len(l:typed)-1:], '[^0-9a-zA-Z_]'))
-"         let s:matches = {}
-"     endif
+function! s:get_active_sources_for_buffer() abort
+    " TODO: cache active sources per buffer
+    let l:active_sources = []
+    for [l:name, l:info] in items(s:sources)
+        let l:blacklisted = 0
 
-"     " do notify sources to refresh
-"     let l:refreshes_calls = []
-"     for [l:name, l:info] in items(a:srcs)
-"         let l:refresh = 0
-"         if has_key(l:info, 'whitelist')
-"             for l:filetype in l:info['whitelist']
-"                 if l:filetype == &filetype || l:filetype == '*'
-"                     let l:refresh = 1
-"                     break
-"                 endif
-"             endfor
-"         endif
-"         if has_key(l:info, 'blacklist')
-"             for l:filetype in l:info['blacklist']
-"                 if l:filetype == &filetype || l:filetype == '*'
-"                     let l:refresh = 0
-"                     break
-"                 endif
-"             endfor
-"         endif
+        if has_key(l:info, 'blacklist')
+            for l:filetype in l:info['blacklist']
+                if l:filetype == &filetype || l:filetype == '*'
+                    let l:blacklisted = 1
+                    break
+                endif
+            endfor
+        endif
 
-"         if l:refresh == 1
-"             let l:refreshes_calls += [l:name]
-"         endif
-"     endfor
+        if l:blacklisted
+            break
+        endif
 
-"     call s:notify_sources_to_refresh(l:refreshes_calls, a:ctx)
-" endfunction
+        if has_key(l:info, 'whitelist')
+            for l:filetype in l:info['whitelist']
+                if l:filetype == &filetype || l:filetype == '*'
+                    let l:active_sources += [l:name]
+                    break
+                endif
+            endfor
+        endif
+    endfor
 
-" function! s:notify_sources_to_refresh(calls, ctx) abort
-"     if exists('s:complete_timer')
-"         call timer_stop(s:complete_timer)
-"         unlet s:complete_timer
-"     endif
+    return l:active_sources
+endfunction
 
-"     let s:complete_timer = timer_start(g:asyncomplete_completion_delay, function('s:complete_timeout'))
-"     let s:complete_timer_ctx = a:ctx
+function! s:python_cm_refresh(ctx, force) abort
+    let l:has_popped_up = 0
+    let l:typed = a:ctx['typed']
+    let l:matchpos = matchstrpos(l:typed, '\k\+$')
+    let l:startpos = l:matchpos[1]
+    let l:endpos = l:matchpos[2]
 
-"     for l:name in a:calls
-"         " try
-"             call s:sources[l:name].completor(s:sources[l:name], a:ctx)
-"         " catch
-"         "     continue
-"         " endtry
-"     endfor
-" endfunction
+    let l:typed_len = l:endpos - l:startpos
+    let l:sources_to_notify = []
+    if l:typed_len == 1 || a:force
+        let l:sources_to_notify = s:get_active_sources_for_buffer()
+    endif
 
-" function! s:python_refresh_completions(ctx) abort
-"     let l:matches = []
+    call s:notify_sources_to_refresh(l:sources_to_notify, a:ctx)
+endfunction
 
-"     let l:names = keys(s:matches)
+function! s:notify_sources_to_refresh(sources, ctx) abort
+    if exists('s:complete_timer')
+        call timer_stop(s:complete_timer)
+        unlet s:complete_timer
+    endif
 
-"     if empty(l:names)
-"         call s:python_complete(a:ctx, a:ctx['col'], [])
-"         return
-"     endif
+    let s:complete_timer = timer_start(g:asyncomplete_completion_delay, function('s:complete_timeout'))
+    let s:complete_timer_ctx = a:ctx
 
-"     let l:startcols = []
-"     for l:item in values(s:matches)
-"         let l:startcols += [l:item['startcol']]
-"     endfor
+    " call s:log('notify_sources_to_refresh', a:sources, a:ctx)
+    for l:name in a:sources
+        try
+            call s:sources[l:name].completor(s:sources[l:name], a:ctx)
+        catch
+            continue
+        endtry
+    endfor
+endfunction
 
-"     let l:startcol = min(l:startcols)
-"     let l:base = a:ctx['typed'][l:startcol-1:]
+function! s:python_refresh_completions(ctx) abort
+    let l:matches = []
 
-"     let l:tmpmatches = []
-"     for [l:name, l:info] in items(s:matches)
-"         let l:curstartcol = s:matches[l:name]['startcol']
-"         let l:curmatches = s:matches[l:name]['matches']
+    let l:names = keys(s:matches)
 
-"         if l:curstartcol > a:ctx['col']
-"             " wrong start col
-"             continue
-"         endif
+    if empty(l:names)
+        call s:python_complete(a:ctx, a:ctx['col'], [])
+        return
+    endif
 
-"         let l:prefix = a:ctx['typed'][l:startcol-1 : col('.') -1]
+    let l:startcols = []
+    for l:item in values(s:matches)
+        let l:startcols += [l:item['startcol']]
+    endfor
 
-"         let l:normalizedcurmatches = []
-"         for l:item in l:curmatches
-"             let l:e = {}
-"             if type(l:item) == type('')
-"                 let l:e['word'] = l:item
-"             else
-"                 let l:e = copy(l:item)
-"                 let l:e['word'] = l:e['word']
-"             endif
-"             let l:normalizedcurmatches += [l:e]
-"         endfor
+    let l:startcol = min(l:startcols)
+    let l:base = a:ctx['typed'][l:startcol-1:]
 
-"         let l:curmatches = l:normalizedcurmatches
+    let l:tmpmatches = []
+    for [l:name, l:info] in items(s:matches)
+        let l:curstartcol = s:matches[l:name]['startcol']
+        let l:curmatches = s:matches[l:name]['matches']
 
-"         for l:item in l:curmatches
-"             if l:item['word'] =~ '^' . l:prefix
-"                 let l:tmpmatches += [l:item]
-"             endif
-"         endfor
-"     endfor
+        if l:curstartcol > a:ctx['col']
+            " wrong start col
+            continue
+        endif
 
-"     call s:core_complete(a:ctx, l:startcol, l:tmpmatches, s:matches)
-" endfunction
+        let l:prefix = a:ctx['typed'][l:startcol-1 : col('.') -1]
 
-" function! s:python_complete(ctx, startcol, matches) abort
-"     if empty(a:matches)
-"         " no need to fire complete message
-"         return
-"     endif
-"     call s:core_complete(a:ctx, a:startcol, a:matches, s:matches)
-" endfunction
+        let l:normalizedcurmatches = []
+        for l:item in l:curmatches
+            let l:e = {}
+            if type(l:item) == type('')
+                let l:e['word'] = l:item
+            else
+                let l:e = copy(l:item)
+                let l:e['word'] = l:e['word']
+            endif
+            let l:normalizedcurmatches += [l:e]
+        endfor
+
+        let l:curmatches = l:normalizedcurmatches
+
+        for l:item in l:curmatches
+            if l:item['word'] =~ '^' . l:prefix
+                let l:tmpmatches += [l:item]
+            endif
+        endfor
+    endfor
+
+    call s:core_complete(a:ctx, l:startcol, l:tmpmatches, s:matches)
+endfunction
+
+function! s:python_complete(ctx, startcol, matches) abort
+    if empty(a:matches)
+        " no need to fire complete message
+        return
+    endif
+    call s:core_complete(a:ctx, a:startcol, a:matches, s:matches)
+endfunction
 
 function! s:python_cm_event(name, event, ctx) abort
     try
@@ -305,40 +321,39 @@ function! s:python_cm_event(name, event, ctx) abort
     endtry
 endfunction
 
-" function! s:core_complete(ctx, startcol, matches, allmatches) abort
+function! s:core_complete(ctx, startcol, matches, allmatches) abort
+    if get(b:, 'asyncomplete_enable', 0) == 0
+        return 2
+    endif
 
-"     if get(b:, 'asyncomplete_enable', 0) == 0
-"         return 2
-"     endif
+    " ignore the request if context has changed
+    if (a:ctx != asyncomplete#context()) || (mode() != 'i')
+        return 1
+    endif
 
-"     " ignore the request if context has changed
-"     if (a:ctx != asyncomplete#context()) || (mode() != 'i')
-"         return 1
-"     endif
+    " something selected by user, do not refresh the menu
+    if s:menu_selected()
+        return 0
+    endif
 
-"     " something selected y the user, do not refresh the menu
-"     if s:menu_selected()
-"         return 0
-"     endif
+    setlocal completeopt-=longest
+    setlocal completeopt+=menuone
+    setlocal completeopt-=menu
+    if &completeopt !~# 'noinsert\|noselect'
+        setlocal completeopt+=noselect
+    endif
 
-"     setlocal completeopt-=longest
-"     setlocal completeopt+=menuone
-"     setlocal completeopt-=menu
-"     if &completeopt !~# 'noinsert\|noselect'
-"         setlocal completeopt+=noselect
-"     endif
+    call complete(a:startcol, a:matches)
+endfunction
 
-"     call complete(a:startcol, a:matches)
-" endfunction
-
-" function! s:complete_timeout(timer)
-"     " finished, clean variable
-"     unlet s:complete_timer
-"     if s:complete_timer_ctx != asyncomplete#context()
-"         return
-"     endif
-"     call s:python_cm_complete_timeout(s:sources, s:complete_timer_ctx)
-" endfunction
+function! s:complete_timeout(timer)
+    " finished, clean variable
+    unlet s:complete_timer
+    if s:complete_timer_ctx != asyncomplete#context()
+        return
+    endif
+    call s:python_cm_complete_timeout(s:sources, s:complete_timer_ctx)
+endfunction
 
 function! s:menu_selected()
     " when the popup menu is visible, v:completed_item will be the

--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -238,7 +238,11 @@ function! s:python_cm_refresh(ctx, force) abort
 
     for l:name in s:get_active_sources_for_buffer()
         let l:source = s:sources[l:name]
-        let l:refresh_pattern = '\k\+$'
+        if has_key(l:source, 'refresh_pattern')
+            let l:refresh_pattern = l:source['refresh_pattern']
+        else
+            let l:refresh_pattern = '\k\+$'
+        endif
         let l:matchpos = matchstrpos(l:typed, l:refresh_pattern)
         let l:startpos = l:matchpos[1]
         let l:endpos = l:matchpos[2]

--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -6,7 +6,7 @@ let s:complete_timer_ctx = {}
 let s:already_setup = 0
 
 function! s:log(...) abort
-    call writefile([json_encode(a:000)], expand('~/Desktop/asyncomplete.log'), 'a')
+    " call writefile([json_encode(a:000)], expand('~/Desktop/asyncomplete.log'), 'a')
 endfunction
 
 " do nothing, place it here only to avoid the message

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -8,3 +8,5 @@ if get(g:, 'asyncomplete_enable_for_all', 1)
 endif
 
 let g:asyncomplete_completion_delay = get(g:, 'asyncomplete_completion_delay', 100)
+inoremap <silent> <expr> <Plug>(asyncomplete_force_refresh) (asyncomplete#menu_selected()?"\<c-y>\<c-r>=asyncomplete#force_refresh()\<CR>":"\<c-r>=asyncomplete#force_refresh()\<CR>")
+" imap <c-space> <Plug>(asyncomplete_force_refresh)

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -8,5 +8,6 @@ if get(g:, 'asyncomplete_enable_for_all', 1)
 endif
 
 let g:asyncomplete_completion_delay = get(g:, 'asyncomplete_completion_delay', 100)
+let g:asyncomplete_log_file = get(g:, 'asyncomplete_log_file', '')
 inoremap <silent> <expr> <Plug>(asyncomplete_force_refresh) (asyncomplete#menu_selected()?"\<c-y>\<c-r>=asyncomplete#force_refresh()\<CR>":"\<c-r>=asyncomplete#force_refresh()\<CR>")
 " imap <c-space> <Plug>(asyncomplete_force_refresh)


### PR DESCRIPTION
**Do not merge. This PR is work in progress**

The primary goal of this rewrite is to support features required by the language protocol server and also change the algorithm on how completion is requested (this algorithm is very similar to how vscode completion works and is mentioned in details at https://github.com/roxma/nvim-completion-manager/issues/30#issuecomment-283281158)

- [x] Core should calculate the start col and cache the results. So `completor` (or `textDocument/compeltion`) is not called in every keystroke.
- [x] Since the results are cached, we should have a mechanism to force refresh cache. This can now be done by `  imap <c-space> <Plug>(asyncomplete_force_refresh)`. This also works if the popup menu is closed and you want to show the completion item.
- [x] Trigger `completor` (or `textDocument/compeltion`) function only if you have typed at least on character.

These above 3 makes the completion work very similar to vscode. This does require some changes to all the completion source providers. Since completion is only called when we have at least one character or whenever force completion is requested which includes even zero characters the min keyword length should not be checked by the sources. If the `completor` function is called the source should just provide the completion at the position.

- [ ] update all sources to remove min keyword length check and always provide completion items if the `completor` function is called.

When you have a large code base it takes few seconds to get completion items from the server since it needs to warm up. This behavior is also seen in vscode. For example, if I type `conso` (`console.log`) in a large typescript codebase it will take few seconds to show the completion items. By the time the core gets the completion items it could be outdated, so rather than showing the old, automatically call notify the same source to get new completion items again.
- [x] automatically notify the source to refresh again if the completion items are outdated. (we need to be careful for slow completion providers. but for now will ignore this since the sources that I use at least till now doesn't seem to have this problem yet. Ideally we could add the outdated results in the cache too)

Currently we only show popup if the min key length is at least 1. But each language provider supports it own `triggerCharacters`. Typing `console.` currently doesn't show the popup since the min key length is 0. But since typescript uses `.` as the trigger character we should show the popup. 

- [x] support `refresh_patterns` similar to ncm. I like this better than supporting `triggerCharacters` since it is lower level than language server protocol. Currently LSP doesn't support sequence of triggerCharacters (https://github.com/Microsoft/language-server-protocol/issues/138) for languages like php and c++ where triggerCharacters should actually be a string instead of char - `["::", "->"]` instead of `[':', '>']`. So having `refresh_patterns` would be much powerful and could easily work in the future when LSP does support trigger characters.
- [ ] ~~add function to convert LSP `triggerCharacters` to `refresh_patterns`. Writing vim regex is difficult for people who are not used to so this could be a good api for those writing new sources.~~. Adding triggerCharacter seems more easier than I thought so not going to implement this anytime soon. Here is an example of adding `.` as triggerCharacter `\(\k\+$\|\.$\)`.

If the completion results is to long the language servers may only return partial results. This means the next character typed should call `completor` (`textDocument/completion`) method again. (Should we append to the cache or replace the cache???)

- [x] support incomplete completion results. This is now implemented. `call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches, 1)`. Fifth parameter is optional and if set to 1 it is considered incomplete result. Next keystroke will trigger `completor()` (`textDocument/completion`).
- [ ] implement an example of incomplete results. Github issues or github user name search. Since we need to make an http request here I would use python. This would also provide a good example of writing a source in external languages.

Bugs:
- [ ] If the autocomplete menu is open and I press backspace the popup menu gets closed. It should not get closed and behave like vscode. Not a huge priority for this CR since you can always use force refresh to show the popup menu. But would be nice to have.