### PR TITLE
add support to disable auto popup via g:asyncomplete_auto_popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ inoremap <expr> <cr> pumvisible() ? "\<C-y>\<cr>" : "\<cr>"
 imap <c-space> <Plug>(asyncomplete_force_refresh)
 ```
 
+### Auto popup
+By default asyncomplete will automatically show the autocomplete popup menu as you start typing.
+If you would like to disable the default behvior set `g:asyncomplete_auto_popup` to 0.
+
+```vim
+let g:asyncomplete_auto_popup = 0
+```
+
+You can use the above `<Plug>(asyncomplete_force_refresh)` to show the popup
+or can you tab to show the autocomplete.
+
+```vim
+let g:asyncomplete_auto_popup = 0
+
+function! s:check_back_space() abort
+    let col = col('.') - 1
+    return !col || getline('.')[col - 1]  =~ '\s'
+endfunction
+
+inoremap <silent><expr> <TAB>
+  \ pumvisible() ? "\<C-n>" :
+  \ <SID>check_back_space() ? "\<TAB>" :
+  \ asyncomplete#force_refresh()
+inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+```
+
 #### Preview Window
 
 To disable preview window:

--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -81,6 +81,10 @@ function! asyncomplete#complete(name, ctx, startcol, matches, ...) abort
 endfunction
 
 function! asyncomplete#force_refresh() abort
+    return asyncomplete#menu_selected() ? "\<c-y>\<c-r>=asyncomplete#_force_refresh()\<CR>" : "\<c-r>=asyncomplete#_force_refresh()\<CR>"
+endfunction
+
+function! asyncomplete#_force_refresh() abort
     if get(b:, 'asyncomplete_enable', 0) == 0
         return
     endif
@@ -241,6 +245,12 @@ function! s:python_cm_refresh(ctx, force) abort
     if a:force
         call s:notify_sources_to_refresh(s:get_active_sources_for_buffer(), a:ctx)
         return
+    endif
+
+    if !pumvisible()
+        if !g:asyncomplete_auto_popup
+            return
+        endif
     endif
 
     let l:typed = a:ctx['typed']

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -7,7 +7,9 @@ if get(g:, 'asyncomplete_enable_for_all', 1)
     au BufEnter * if exists ('b:asyncomplete_enable') == 0 | call asyncomplete#enable_for_buffer() | endif
 endif
 
+let g:asyncomplete_auto_popup = get(g:, 'asyncomplete_auto_popup', 1)
 let g:asyncomplete_completion_delay = get(g:, 'asyncomplete_completion_delay', 100)
 let g:asyncomplete_log_file = get(g:, 'asyncomplete_log_file', '')
-inoremap <silent> <expr> <Plug>(asyncomplete_force_refresh) (asyncomplete#menu_selected()?"\<c-y>\<c-r>=asyncomplete#force_refresh()\<CR>":"\<c-r>=asyncomplete#force_refresh()\<CR>")
+
 " imap <c-space> <Plug>(asyncomplete_force_refresh)
+inoremap <silent> <expr> <Plug>(asyncomplete_force_refresh) asyncomplete#force_refresh()


### PR DESCRIPTION
fixes #5 

@andreypopp let me know if this works for you. You should be able to do something like this.

```vim
let g:asyncomplete_auto_popup = 0

function! s:check_back_space() abort
    let col = col('.') - 1
    return !col || getline('.')[col - 1]  =~ '\s'
endfunction

inoremap <silent><expr> <TAB>
    \ pumvisible() ? "\<C-n>" :
    \ <SID>check_back_space() ? "\<TAB>" :
    \ asyncomplete#force_refresh()
inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
```