### PR TITLE
add support for priority (fixes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ asyncomplete.vim deliberately does not contain any sources. Please use one of th
 * Typescript via [asyncomplete-tscompletejob.vim](https://github.com/prabirshrestha/asyncomplete-tscompletejob.vim)
 * *can't find what you are looking for? write one instead an send a PR to be included here*
 
+### Priority
+
+Use `priority` to control the order of the source. Highest priority comes first. `priority` is optional and defaults to `0` when registering a source.
+
 ### Example
 
 ```vim
@@ -110,6 +114,7 @@ endfunction
 call asyncomplete#register_source({
     \ 'name': 'javascript',
     \ 'whitelist': ['javascript'],
+    \ 'priority': 5,
     \ 'completor': function('s:js_completor'),
     \ })
 ```

--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -300,6 +300,12 @@ function! s:notify_sources_to_refresh(sources, ctx) abort
     endfor
 endfunction
 
+function! s:sort_sources_by_priority(source1, source2) abort
+    let l:priority1 = get(get(s:sources, a:source1, {}), 'priority', 0)
+    let l:priority2 = get(get(s:sources, a:source2, {}), 'priority', 0)
+    return l:priority1 > l:priority2 ? -1 : (l:priority1 != l:priority2)
+endfunction
+
 function! s:python_refresh_completions(ctx) abort
     let l:matches = []
 
@@ -319,9 +325,13 @@ function! s:python_refresh_completions(ctx) abort
     let l:base = a:ctx['typed'][l:startcol-1:]
 
     let l:tmpmatches = []
-    for [l:name, l:info] in items(s:matches)
-        let l:curstartcol = s:matches[l:name]['startcol']
-        let l:curmatches = s:matches[l:name]['matches']
+
+    let l:sources = sort(keys(s:matches), function('s:sort_sources_by_priority'))
+
+    for l:name in l:sources
+        let l:info = s:matches[l:name]
+        let l:curstartcol = l:info['startcol']
+        let l:curmatches = l:info['matches']
 
         if l:curstartcol > a:ctx['col']
             " wrong start col


### PR DESCRIPTION
PR for #9

@andreypopp let me know if this works out. `priority` is optional and defaults to 0.

```vim
  au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#tscompletejob#get_source_options({
    \ 'name': 'tscompletejob',
    \ 'whitelist': ['typescript'],
    \ 'priority': 9,
    \ 'completor': function('asyncomplete#sources#tscompletejob#completor'),
    \ }))
  au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#buffer#get_source_options({
    \ 'name': 'buffer',
    \ 'whitelist': ['*'],
    \ 'priority': 0,
    \ 'completor': function('asyncomplete#sources#buffer#completor'),
    \ }))
```