### PR TITLE
flag to disable force refresh on context changed

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -85,7 +85,9 @@ function! asyncomplete#complete(name, ctx, startcol, matches, ...) abort
 
     " ignore the request if context has changed
     if asyncomplete#context_changed(a:ctx)
-        call s:python_cm_complete(a:name, a:ctx, a:startcol, a:matches, l:refresh, 1)
+        if g:asyncomplete_force_refresh_on_context_changed
+            call s:python_cm_complete(a:name, a:ctx, a:startcol, a:matches, l:refresh, 1)
+        endif
         return 1
     endif
 

--- a/doc/asyncomplete.txt
+++ b/doc/asyncomplete.txt
@@ -40,6 +40,15 @@ g:asyncomplete_auto_popup                           *g:asyncomplete_auto_popup*
 
     Automatically show the autocomplete popup menu as you start typing.
 
+g:asyncomplete_force_refresh_on_context_changed *g:asyncomplete_force_refresh_on_context_changed*
 
+    Type: |Number|
+    Default: `0`
+
+    Automatically force refresh the autocomplete if the context has
+    already changed when results were received.
+
+    Note Setting to 1 may call force_refresh often which may slow down vim
+    specially for those sources that are heavy in computation in vimscript.
 ===============================================================================
   vim:tw=78:ts=4:sts=4:sw=4:ft=help:norl:

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -12,5 +12,9 @@ let g:asyncomplete_completion_delay = get(g:, 'asyncomplete_completion_delay', 1
 let g:asyncomplete_log_file = get(g:, 'asyncomplete_log_file', '')
 let g:asyncomplete_remove_duplicates = get(g:, 'asyncomplete_remove_duplicates', 0)
 
+" Setting it to true may slow/hang vim especially on slow are sources such as asyncomplete-lsp.vim
+" use asyncomplete_force_refersh to retrive the latest autocomplete results instead.
+let g:asyncomplete_force_refresh_on_context_changed = get(g:, 'asyncomplete_force_referesh_on_context_changed', 0)
+
 " imap <c-space> <Plug>(asyncomplete_force_refresh)
 inoremap <silent> <expr> <Plug>(asyncomplete_force_refresh) asyncomplete#force_refresh()


### PR DESCRIPTION
Since vimscript is sync and doesn't have rpc having expensive scripts like asyncomplete-lsp that parses json a lot can make vim unresponsive, so disable this by default.