### PR TITLE
Note minimum NeoVim version

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ asyncomplete.vim deliberately does not contain any sources. Please use one of th
 #### Language Server Protocol (LSP)
 [Language Server Protocol](https://github.com/Microsoft/language-server-protocol) via [vim-lsp](https://github.com/prabirshrestha/vim-lsp) and [asyncomplete-lsp.vim](https://github.com/prabirshrestha/asyncomplete-lsp.vim)
 
+**Please note** that vim-lsp setup for neovim requires neovim v0.2.0 or higher, since it uses lambda setup.
+
 ```vim
 Plug 'prabirshrestha/asyncomplete.vim'
 Plug 'prabirshrestha/async.vim'
@@ -105,8 +107,6 @@ endif
 ```
 
 **Refer to [vim-lsp wiki](https://github.com/prabirshrestha/vim-lsp/wiki/Servers) for configuring other language servers.** Besides auto-complete language server support other features such as go to definition, find references, renaming symbols, document symbols, find workspace symbols, formatting and so on.
-
-**Please note** that vim-lsp setup for certain LSP servers requires support for v0.2.0+ of neovim.
 
 *in alphabetical order*
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 asyncomplete.vim
 ================
 
-Provide async autocompletion for vim8 and neovim (0.2.0+) with `timers`.
+Provide async autocompletion for vim8 and neovim with `timers`.
 This repository is fork of [https://github.com/roxma/nvim-complete-manager](https://github.com/roxma/nvim-complete-manager)
 in pure vim script with python dependency removed.
 
@@ -105,6 +105,8 @@ endif
 ```
 
 **Refer to [vim-lsp wiki](https://github.com/prabirshrestha/vim-lsp/wiki/Servers) for configuring other language servers.** Besides auto-complete language server support other features such as go to definition, find references, renaming symbols, document symbols, find workspace symbols, formatting and so on.
+
+**Please note** that setup for certain LSP servers requires support for v0.2.0+ of neovim.
 
 *in alphabetical order*
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 asyncomplete.vim
 ================
 
-Provide async autocompletion for vim8 and neovim with `timers`.
+Provide async autocompletion for vim8 and neovim (0.2.0+) with `timers`.
 This repository is fork of [https://github.com/roxma/nvim-complete-manager](https://github.com/roxma/nvim-complete-manager)
 in pure vim script with python dependency removed.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ endif
 
 **Refer to [vim-lsp wiki](https://github.com/prabirshrestha/vim-lsp/wiki/Servers) for configuring other language servers.** Besides auto-complete language server support other features such as go to definition, find references, renaming symbols, document symbols, find workspace symbols, formatting and so on.
 
-**Please note** that setup for certain LSP servers requires support for v0.2.0+ of neovim.
+**Please note** that vim-lsp setup for certain LSP servers requires support for v0.2.0+ of neovim.
 
 *in alphabetical order*
 


### PR DESCRIPTION
Resolves #40.

There are of course other ways to highlight the minimum version required; I just thought this would be the easiest and most immediately-visible way.