### PR TITLE
Fix init_lua error

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -21,7 +21,7 @@ let s:next_tick_single_exec_metadata = {}
 let s:has_lua = has('lua') || has('nvim-0.2.2')
 let s:supports_getbufinfo = exists('*getbufinfo')
 let s:supports_smart_completion = exists('##TextChangedP')
-let s:asyncomplete_folder = fnamemodify(expand('<sfile>:p:h') . '/../', ':p:h')
+let s:asyncomplete_folder = fnamemodify(expand('<sfile>:p:h') . '/../', ':p:h:gs?\\?/?')
 
 function! s:init_lua() abort
     exec 'lua asyncomplete_folder="' . s:asyncomplete_folder . '"'


### PR DESCRIPTION
# Summary

Fix init_lua error

## Screenshot

![image](https://user-images.githubusercontent.com/99910/44556345-42966e80-a774-11e8-8b8e-63a216f3b23d.png)

## Environment Information

 * OS: Windows10

 * `:version` output:
```
VIM - Vi IMproved 8.1 (2018 May 18, compiled Aug 23 2018 22:02:01)
MS-Windows 64 ビット GUI 版 with OLE サポート
適用済パッチ: 1-325
Compiled by appveyor@APPVYR-WIN
Huge 版 with GUI.  機能の一覧 有効(+)/無効(-)
+acl                +cindent            +cursorshape        +farsi              +jumplist           +mksession          +path_extra         +ruby/dyn           +tcl/dyn            +vertsplit          -xfontset
+arabic             +clientserver       +dialog_con_gui     +file_in_path       +keymap             +modify_fname       +perl/dyn           +scrollbind         -termguicolors      +virtualedit        -xim
+autocmd            +clipboard          +diff               +find_in_path       +lambda             +mouse              +persistent_undo    +signs              +terminal           +visual             +xpm_w32
+autochdir          +cmdline_compl      +digraphs           +float              +langmap            +mouseshape         -postscript         +smartindent        -tgetent            +visualextra        -xterm_save
+autoservername     +cmdline_hist       +directx            +folding            +libcall            +multi_byte_ime/dyn +printer            +startuptime        -termresponse       +viminfo            
+balloon_eval       +cmdline_info       -dnd                -footer             +linebreak          +multi_lang         +profile            +statusline         +textobjects        +vreplace           
-balloon_eval_term  +comments           -ebcdic             +gettext/dyn        +lispindent         +mzscheme/dyn       +python/dyn         -sun_workshop       +timers             -vtp                
+browse             +conceal            +emacs_tags         -hangul_input       +listcmds           +netbeans_intg      +python3/dyn        +syntax             +title              +wildignore         
++builtin_terms     +cryptv             +eval               +iconv/dyn          +localmap           +num64              +quickfix           +tag_binary         +toolbar            +wildmenu           
+byte_offset        +cscope             +ex_extra           +insert_expand      +lua/dyn            +ole                +reltime            +tag_old_static     +user_commands      +windows            
+channel            +cursorbind         +extra_search       +job                +menu               +packages           +rightleft          -tag_any_white      +vartabs            +writebackup        
      システム vimrc: "$VIM\vimrc"
      ユーザー vimrc: "$HOME\_vimrc"
   第2ユーザー vimrc: "$HOME\vimfiles\vimrc"
   第3ユーザー vimrc: "$VIM\_vimrc"
       ユーザー exrc: "$HOME\_exrc"
    第2ユーザー exrc: "$VIM\_exrc"
     システム gvimrc: "$VIM\gvimrc"
     ユーザー gvimrc: "$HOME\_gvimrc"
  第2ユーザー gvimrc: "$HOME\vimfiles\gvimrc"
  第3ユーザー gvimrc: "$VIM\_gvimrc"
  デフォルトファイル: "$VIMRUNTIME\defaults.vim"
    システムメニュー: "$VIMRUNTIME\menu.vim"
コンパイル: cl -c /W3 /nologo  -I. -Iproto -DHAVE_PATHDEF -DWIN32  -DFEAT_CSCOPE -DFEAT_TERMINAL -DFEAT_NETBEANS_INTG -DFEAT_JOB_CHANNEL   -DFEAT_XPM_W32   -DWINVER=0x0501 -D_WIN32_WINNT=0x0501 /MP -DHAVE_STDINT_H /Ox /GL -DNDEBUG  /Zl /MT -DFEAT_OLE -DFEAT_MBYTE_IME -DDYNAMIC_IME -DFEAT_MBYTE -DFEAT_GUI_W32 -DFEAT_DIRECTX -DDYNAMIC_DIRECTX -DFEAT_DIRECTX_COLOR_EMOJI -DDYNAMIC_ICONV -DDYNAMIC_GETTEXT -DFEAT_TCL -DDYNAMIC_TCL -DDYNAMIC_TCL_DLL=\"tcl86t.dll\" -DDYNAMIC_TCL_VER=\"8.6\" -DFEAT_LUA -DDYNAMIC_LUA -DDYNAMIC_LUA_DLL=\"lua53.dll\" -DFEAT_PYTHON -DDYNAMIC_PYTHON -DDYNAMIC_PYTHON_DLL=\"python27.dll\" -DFEAT_PYTHON3 -DDYNAMIC_PYTHON3 -DDYNAMIC_PYTHON3_DLL=\"python36.dll\" -DFEAT_MZSCHEME -I "C:\Program Files\Racket\include" -DMZ_PRECISE_GC -DDYNAMIC_MZSCHEME -DDYNAMIC_MZSCH_DLL=\"libracket3m_a36fs8.dll\" -DDYNAMIC_MZGC_DLL=\"libracket3m_a36fs8.dll\" -DFEAT_PERL -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -DDYNAMIC_PERL -DDYNAMIC_PERL_DLL=\"perl524.dll\" -DFEAT_RUBY -DDYNAMIC_RUBY -DDYNAMIC_RUBY_VER=24 -DDYNAMIC_RUBY_DLL=\"x64-msvcrt-ruby240.dll\" -DFEAT_HUGE /Fd.\ObjGXOULYHTRZAMD64/ /Zi
リンク: link  /nologo /subsystem:windows,5.02 /opt:ref /LTCG:STATUS /HIGHENTROPYVA:NO oldnames.lib kernel32.lib advapi32.lib shell32.lib gdi32.lib  comdlg32.lib ole32.lib netapi32.lib uuid.lib /machine:AMD64 gdi32.lib version.lib   winspool.lib comctl32.lib advapi32.lib shell32.lib netapi32.lib  /machine:AMD64  libcmt.lib oleaut32.lib user32.lib  /nodefaultlib:lua53.lib  /STACK:8388608  /nodefaultlib:python27.lib /nodefaultlib:python36.lib   "C:\Tcl\lib\tclstub86.lib" WSock32.lib xpm\x64\lib-vc14\libXpm.lib /PDB:gvim.pdb -debug
```