### PR TITLE
Fix flickering popup menu

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -253,7 +253,7 @@ function! s:get_refresh_pattern(source) abort
 endfunction
 
 function! s:remote_refresh(ctx, force) abort
-    let l:has_popped_up = 0
+    let s:has_popped_up = 0
     if a:force
         call s:notify_sources_to_refresh(s:get_active_sources_for_buffer(), a:ctx)
         return


### PR DESCRIPTION
## Problem
The popup menu is blinking/flickering often.

## Cause
- there is no reset code for `s:has_poped_up`
- `s:remote_refresh` calls `s:core_complete` via `s:python_refresh_completions` when the flag `g:asyncomplete_smart_completion` is set
- Related to above, `s:python_refresh_completions` is not called even if the flag `'refresh'` is set.

## Solution
- `l:has_poped_up` -> `s:has_poped_up`, since `l:has_poped_up` is never used and it seems a typo
- Modify the condition to call `s:python_refresh_completions` in `s:remote_refresh`

## Comment
The solution is just my guess.  Although it is working on my PC, I could have misunderstanding on the design of this plugin.