### PR TITLE
Allow custom filter for sources

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -444,11 +444,14 @@ function! s:python_refresh_completions(ctx) abort
             let l:normalizedcurmatches += [l:e]
         endfor
 
-        if s:supports_smart_completion()
-            let l:filtered_matches += l:normalizedcurmatches
+        if has_key(s:sources[l:name], 'filter')
+            let l:FilterFunc = s:sources[l:name]['filter']
+        elseif s:supports_smart_completion()
+            let l:FilterFunc = function('s:custom_filter_completion_items')
         else
-            let l:filtered_matches += s:filter_completion_items(l:prefix, l:normalizedcurmatches)
+            let l:FilterFunc = function('s:filter_completion_items')
         endif
+        let l:filtered_matches += l:FilterFunc(l:prefix, l:normalizedcurmatches)
     endfor
 
     call s:core_complete(a:ctx, l:startcol, l:filtered_matches, s:matches)
@@ -493,8 +496,7 @@ function! s:core_complete(ctx, startcol, matches, allmatches) abort
 
     call asyncomplete#log('core', 's:core_complete')
 
-    let l:candidates = s:supports_smart_completion() ? s:custom_filter_completion_items(a:ctx['typed'][a:startcol-1 : col('.') - 1], a:matches) : a:matches
-    call complete(a:startcol, l:candidates)
+    call complete(a:startcol, a:matches)
 endfunction
 
 function! s:supports_smart_completion() abort


### PR DESCRIPTION
This patch allows sources to have its own candidate-filtering function. Although the internal filter is fast and smart enough, there could be sources which required its own filtering function for special purposes. 

I wrote an example, [asyncomplete-unicodesymbol](https://github.com/machakann/asyncomplete-unicodesymbol). This source completes unicode symbols, like `α` if user types `\alpha`. In this case, `α` never matches to `\alpha` with the internal filter. (Sorry, this package may not be a good poc since it has a requirement... Let me paste an gif)

![unicodesymbol](https://user-images.githubusercontent.com/480049/52911292-b1482500-32dc-11e9-8c13-b373d0915def.gif)


If a source has the `filter` key it is used instead of the internal filter. Its value should be a funcref which takes two arguments; prefix and candidates. The `prefix` is the text before the cursor and `candidates` is the list of completion candidates.

I should note that this patch has a little speed penalty. Without this patch, `s:custom_filter_completion_items()` is called only once in a completion. However, it gets increased to the number of souces without custom filters.