### PR TITLE
Fix "Undefined variable: b:asyncomplete_enable" error in |command-line-window|

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -204,7 +204,7 @@ function! s:update_trigger_characters() abort
 endfunction
 
 function! s:should_skip() abort
-    if mode() isnot# 'i' || !b:asyncomplete_enable
+    if mode() isnot# 'i' || !get(b:, 'asyncomplete_enable', 0)
         return 1
     else
         return 0


### PR DESCRIPTION
1. launch `vim`
2. type `q:` to enter into |command-line-window|
3. type any character

The following error occurs.

```console
:
Error detected while processing function <SNR>93_on_text_changed_i[1]..<SNR>93_maybe_notif
y_on_change[6]..<SNR>92_on_change[1]..<SNR>92_should_skip:
line    1:
E121: Undefined variable: b:asyncomplete_enable
```

(cf. |BufEnter| and |CmdwinEnter|)