### PR TITLE
fix sample code for document of g:asyncomplete_preprocessor

### DIFF
--- a/doc/asyncomplete.txt
+++ b/doc/asyncomplete.txt
@@ -62,7 +62,7 @@ g:asyncomplete_preprocessor                        *g:asyncomplete_preprocessor*
     Set a function to allow custom filtering or sorting.
     Below example implements removing duplicates.
 
-      function! s:my_asyncomplete_preprocessor(ctx, matches) abort
+      function! s:my_asyncomplete_preprocessor(options, matches) abort
         let l:visited = {}
         let l:items = []
         for [l:source_name, l:matches] in items(a:matches)
@@ -76,7 +76,7 @@ g:asyncomplete_preprocessor                        *g:asyncomplete_preprocessor*
           endfor
         endfor
 
-        call asyncomplete#preprocess_complete(a:ctx, l:items)
+        call asyncomplete#preprocess_complete(a:options, l:items)
       endfunction
 
       let g:asyncomplete_preprocessor = [function('s:my_asyncomplete_preprocessor')]


### PR DESCRIPTION
The original code emits `E121: Undefined variable: a:options` error so I fixed the document.