### PR TITLE
Fix mismatch between b:asyncomplete_active_sources/triggers and s:ser…

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -84,6 +84,17 @@ function! asyncomplete#register_source(info) abort
             endfor
             execute 'augroup end'
         endif
+
+        if exists('b:asyncomplete_active_sources')
+          unlet b:asyncomplete_active_sources
+          call s:get_active_sources_for_buffer()
+        endif
+
+        if exists('b:asyncomplete_triggers')
+          unlet b:asyncomplete_triggers
+          call s:update_trigger_characters()
+        endif
+
         return 1
     endif
 endfunction


### PR DESCRIPTION
This PR fixes a problem that `b:asyncomplete_active_sources` and `b:asyncomplete_triggers` will not be updated when `s:on_insert_enter()` has been called before `asyncomplete#register_source()` is called.

For example, when a user has got into insert mode before `asyncomplete#register_source()` is called, which is hooked on lsp_server_init (https://github.com/prabirshrestha/asyncomplete-lsp.vim/blob/master/plugin/asyncomplete-lsp.vim#L35), this problem will be reproduced.

And I guess this PR may be related to https://github.com/prabirshrestha/asyncomplete.vim/issues/138 because `asyncomplete#force_refresh()` looks only uses `b:asyncomplete_active_sources` (https://github.com/prabirshrestha/asyncomplete.vim/blob/master/autoload/asyncomplete.vim#L358)