### PR TITLE
Filter based on each source's startcol

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -436,13 +436,19 @@ endfunction
 
 function! s:default_preprocessor(options, matches) abort
     let l:items = []
+    let l:startcols = []
     for [l:source_name, l:matches] in items(a:matches)
+        let l:startcol = l:matches['startcol']
+        let l:base = a:options['typed'][l:startcol - 1:]
         for l:item in l:matches['items']
-            if stridx(l:item['word'], a:options['base']) == 0
+            if stridx(l:item['word'], l:base) == 0
+                let l:startcols += [l:startcol]
                 call add(l:items, l:item)
             endif
         endfor
     endfor
+
+    let a:options['startcol'] = min(l:startcols)
 
     call asyncomplete#preprocess_complete(a:options, l:items)
 endfunction


### PR DESCRIPTION
Fixes #151 - specifically when `asyncomplete-file` and another source are used together they conflict due to conflicting `startcol` values.

1. Each source's completions are filtered based on their own `startcol` so matches that are valid aren't removed
2. The only `startcol` value we pass on is the minimum value of all valid source completions. Sources without valid completions are not counted for their `startcol` value

Theoretically, it's possible still to have two sources that generates conflicting `startcol` values and both provide completions. I've not seen this in practice.