### PR TITLE
Adding get_source_info() and get_source_names()

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -66,6 +66,14 @@ function! asyncomplete#disable_for_buffer() abort
     let b:asyncomplete_enable = 0
 endfunction
 
+function! asyncomplete#get_source_names() abort
+    return keys(s:sources)
+endfunction
+
+function! asyncomplete#get_source_info(source_name) abort
+    return s:sources[a:source_name]
+endfunction
+
 function! asyncomplete#register_source(info) abort
     if has_key(s:sources, a:info['name'])
         call asyncomplete#log('core', 'duplicate asyncomplete#register_source', a:info['name'])

--- a/doc/asyncomplete.txt
+++ b/doc/asyncomplete.txt
@@ -92,18 +92,48 @@ g:asyncomplete_preprocessor                        *g:asyncomplete_preprocessor*
 
 asyncomplete#close_popup()                         *asyncomplete#close_popup()*
 
-    Insert selected candidate and close popup menu. 
+    Insert selected candidate and close popup menu.
     Following example prevents popup menu from re-opening after insertion.
-
-      inoremap <expr> <C-y> pumvisible() ? asyncomplete#close_popup() : "\<C-y>"
-
+>
+    inoremap <expr> <C-y> pumvisible() ? asyncomplete#close_popup() : "\<C-y>"
+<
 asyncomplete#cancel_popup()                       *asyncomplete#cancel_popup()*
 
-    Cancel completion and close popup menu. 
+    Cancel completion and close popup menu.
     Following example prevents popup menu from re-opening after cancellation.
+>
+    inoremap <expr> <C-e> pumvisible() ? asyncomplete#cancel_popup() : "\<C-e>"
+<
+asyncomplete#get_source_info({source-name})    *asyncomplete#get_source_info()*
 
-      inoremap <expr> <C-e> pumvisible() ? asyncomplete#cancel_popup() : "\<C-e>"
+    Get the source configuration info as dict.
+    Below example implements a priority sort function.
+>
+    function! s:sort_by_priority_preprocessor(options, matches) abort
+      let l:items = []
+      for [l:source_name, l:matches] in items(a:matches)
+        for l:item in l:matches['items']
+          if stridx(l:item['word'], a:options['base']) == 0
+            let l:item['priority'] =
+                \ get(asyncomplete#get_source_info(l:source_name),'priority',0)
+            call add(l:items, l:item)
+          endif
+        endfor
+      endfor
 
+      let l:items = sort(l:items, {a, b -> b['priority'] - a['priority']})
+
+      call asyncomplete#preprocess_complete(a:options, l:items)
+    endfunction
+
+    let g:asyncomplete_preprocessor = [function('s:sort_by_priority_preprocessor')]
+<
+asyncomplete#get_source_names()               *asyncomplete#get_source_names()*
+
+    Get the registered source names list.
+>
+    let source_names = asyncomplete#get_source_names()
+<
 ===============================================================================
 4. Global vim configuration                          *asyncomplete-global-config*
 

--- a/doc/asyncomplete.txt
+++ b/doc/asyncomplete.txt
@@ -131,9 +131,7 @@ asyncomplete#get_source_info({source-name})    *asyncomplete#get_source_info()*
 asyncomplete#get_source_names()               *asyncomplete#get_source_names()*
 
     Get the registered source names list.
->
-    let source_names = asyncomplete#get_source_names()
-<
+
 ===============================================================================
 4. Global vim configuration                          *asyncomplete-global-config*
 


### PR DESCRIPTION
How about adding get_source_info() and get_source_names() like get_server_info() and get_server_names() in vim-lsp?

Especially, get_source_info() makes us easier to create custom preprocessors e.g.) sorting by priority like following.

```vim
au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#file#get_source_options({
      \ 'name': 'file',
      \ 'whitelist': ['*'],
      \ 'priority': 50,
      \ 'completor': function('asyncomplete#sources#file#completor')
      \ }))

au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#buffer#get_source_options({
      \ 'name': 'buffer',
      \ 'whitelist': ['*'],
      \ 'priority': 0,
      \ 'completor': function('asyncomplete#sources#buffer#completor'),
      \ }))

function! s:sort_by_priority_preprocessor(options, matches) abort
  let l:items = []
  for [l:source_name, l:matches] in items(a:matches)
    for l:item in l:matches['items']
      if stridx(l:item['word'], a:options['base']) == 0
        let l:item['priority'] = get(asyncomplete#get_source_info(l:source_name),'priority',0)
        call add(l:items, l:item)
      endif
    endfor
  endfor
                                                                                                
  let l:items = sort(l:items, {a, b -> b['priority'] - a['priority']})
                                                                                                
  call asyncomplete#preprocess_complete(a:options, l:items)
endfunction

let g:asyncomplete_preprocessor = [function('s:sort_by_priority_preprocessor')]
```