### PR TITLE
[WIP] Improve trigger character handling

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -299,8 +299,12 @@ function! s:on_change() abort
             endif
         endfor
     else
+        " Clear current cache on below cases.
+        " 1. no match to keyword patterns
+        " 2. not exists in `s:sources_to_notify`
+        " 3. ctx['lum'] was changed
         for l:source_name in b:asyncomplete_active_sources
-            if !has_key(l:sources_to_notify, l:source_name) && has_key(s:matches, l:source_name)
+            if !has_key(l:sources_to_notify, l:source_name) && has_key(s:matches, l:source_name) && l:ctx['lnum'] != s:matches[l:source_name]['ctx']['lnum']
                 let s:matches[l:source_name].items = []
             endif
         endfor

--- a/autoload/asyncomplete/utils/_on_change/textchangedp.vim
+++ b/autoload/asyncomplete/utils/_on_change/textchangedp.vim
@@ -17,7 +17,6 @@ function! s:setup_if_required() abort
     augroup asyncomplete_utils_on_change_text_changed_p
         autocmd!
         autocmd InsertEnter * call s:on_insert_enter()
-        autocmd InsertLeave * call s:on_insert_leave()
         autocmd TextChangedI * call s:on_text_changed_i()
         autocmd TextChangedP * call s:on_text_changed_p()
     augroup END
@@ -32,11 +31,7 @@ function! s:unregister(obj, cb) abort
 endfunction
 
 function! s:on_insert_enter() abort
-    let s:previous_position = getcurpos()
-endfunction
-
-function! s:on_insert_leave() abort
-    unlet s:previous_position
+    call timer_start(100, { -> s:maybe_notify_on_change() })
 endfunction
 
 function! s:on_text_changed_i() abort
@@ -48,12 +43,8 @@ function! s:on_text_changed_p() abort
 endfunction
 
 function! s:maybe_notify_on_change() abort
-    " enter to new line or backspace to previous line shouldn't cause change trigger
-    let l:previous_position = s:previous_position
-    let s:previous_position = getcurpos()
-    if l:previous_position[1] ==# getcurpos()[1]
-        for l:Cb in s:callbacks
-            call l:Cb()
-        endfor
-    endif
+    for l:Cb in s:callbacks
+        call l:Cb()
+    endfor
 endfunction
+

--- a/autoload/asyncomplete/utils/_on_change/timer.vim
+++ b/autoload/asyncomplete/utils/_on_change/timer.vim
@@ -30,12 +30,10 @@ function! s:unregister(obj, cb) abort
 endfunction
 
 function! s:on_insert_enter() abort
-    let s:previous_position = getcurpos()
-    call s:change_tick_start()
+    call s:change_tick_start(v:true)
 endfunction
 
 function! s:on_insert_leave() abort
-    unlet s:previous_position
     call s:change_tick_stop()
 endfunction
 
@@ -43,9 +41,14 @@ function! s:on_text_changed_i() abort
     call s:check_changes()
 endfunction
 
-function! s:change_tick_start() abort
+function! s:change_tick_start(...) abort
+    let l:force = get(a:000, 0, v:false)
     if !exists('s:change_timer')
-        let s:last_tick = s:change_tick()
+        if l:force
+            let s:last_tick = [-1]
+        else
+            let s:last_tick = s:change_tick()
+        endif
         " changes every 30ms, which is 0.03s, it should be fast enough
         let s:change_timer = timer_start(30, function('s:check_changes'), { 'repeat': -1 })
     endif
@@ -68,16 +71,11 @@ function! s:check_changes(...) abort
 endfunction
 
 function! s:maybe_notify_on_change() abort
-    " enter to new line or backspace to previous line shouldn't cause change trigger
-    let l:previous_position = s:previous_position
-    let s:previous_position = getcurpos()
-    if l:previous_position[1] ==# getcurpos()[1]
-        for l:Cb in s:callbacks
-            call l:Cb()
-        endfor
-    endif
+    for l:Cb in s:callbacks
+        call l:Cb()
+    endfor
 endfunction
 
 function! s:change_tick() abort
-    return [b:changedtick, getcurpos()]
+    return [b:changedtick]
 endfunction


### PR DESCRIPTION
Fixes https://github.com/prabirshrestha/asyncomplete.vim/issues/173

New implementation detect below cases as text changed.

### InsertEnter
When `InsertEnter` to the tag attributes, I hope to show attribute's candidates.

```html
<div aria-autocomplete="|"></div>
```


### Line changes.
When apply `additionalTextEdits`, I hope to show imported package's candidates.

```go
package main

import "fmt"

func main() {
  fmt.|
}
```

