### PR TITLE
Only warn about missing timers functionality once

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -19,6 +19,8 @@ if !has('timers')
     else
         call asyncomplete#log('vim compiled with timers required.')
     endif
+    " Clear augroup so this message is only displayed once.
+    au! asyncomplete_enable *
     finish
 endif
 


### PR DESCRIPTION
plugin/asyncomplete.vim sets up an autocmd to invoke
asyncomplete#enable_for_buffer() for every BufEnter. If we don't clear
this autocmd, then it will try to call that function, which will try to
source the autoload file, which outputs the error again.

Clearing that autocmd group stops the cycle and limits the number of
warnings to one.