### PR TITLE
Remove paired suffixes

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -459,8 +459,8 @@ function! s:default_preprocessor(options, matches) abort
         for l:item in l:matches['items']
             if stridx(l:item['word'], l:base) == 0
                 " Strip pair characters. If pre-typed text is "{", candidates
-				" should have "}" suffix.
-	            if has_key(s:pair, l:base)
+                " should have "}" suffix.
+                if has_key(s:pair, l:base)
                     let [l:lhs, l:rhs, l:str] = [l:base, s:pair[l:base], l:item['word']]
                     if len(l:str) > 1 && l:str[0] ==# l:lhs && l:str[-1:] ==# l:rhs
                         let l:item['word'] = l:str[:-2]

--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -445,9 +445,6 @@ endfunction
 let s:pair = {
 \  '"':  '"',
 \  '''':  '''',
-\  '{':  '}',
-\  '[':  ']',
-\  '(':  ')',
 \}
 
 function! s:default_preprocessor(options, matches) abort
@@ -458,10 +455,10 @@ function! s:default_preprocessor(options, matches) abort
         let l:base = a:options['typed'][l:startcol - 1:]
         for l:item in l:matches['items']
             if stridx(l:item['word'], l:base) == 0
-                " Strip pair characters. If pre-typed text is "{", candidates
-                " should have "}" suffix.
-                if has_key(s:pair, l:base)
-                    let [l:lhs, l:rhs, l:str] = [l:base, s:pair[l:base], l:item['word']]
+                " Strip pair characters. If pre-typed text is '"', candidates
+                " should have '"' suffix.
+                if has_key(s:pair, l:base[0])
+                    let [l:lhs, l:rhs, l:str] = [l:base[0], s:pair[l:base[0]], l:item['word']]
                     if len(l:str) > 1 && l:str[0] ==# l:lhs && l:str[-1:] ==# l:rhs
                         let l:item['word'] = l:str[:-2]
                     endif

--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -442,6 +442,14 @@ function! s:recompute_pum(...) abort
     endif
 endfunction
 
+let s:pair = {
+\  '"':  '"',
+\  '''':  '''',
+\  '{':  '}',
+\  '[':  ']',
+\  '(':  ')',
+\}
+
 function! s:default_preprocessor(options, matches) abort
     let l:items = []
     let l:startcols = []
@@ -450,6 +458,14 @@ function! s:default_preprocessor(options, matches) abort
         let l:base = a:options['typed'][l:startcol - 1:]
         for l:item in l:matches['items']
             if stridx(l:item['word'], l:base) == 0
+                " Strip pair characters. If pre-typed text is "{", candidates
+				" should have "}" suffix.
+	            if has_key(s:pair, l:base)
+                    let [l:lhs, l:rhs, l:str] = [l:base, s:pair[l:base], l:item['word']]
+                    if len(l:str) > 1 && l:str[0] ==# l:lhs && l:str[-1:] ==# l:rhs
+                        let l:item['word'] = l:str[:-2]
+                    endif
+                endif
                 let l:startcols += [l:startcol]
                 call add(l:items, l:item)
             endif


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/10111/74592804-35f08f00-5068-11ea-922c-b1ddfe6b9e7d.gif)

asyncomplete removes prefix of candidates with startcool. So if the pre-typed text is `"`, `'`, `{`, `[` or `(`, suffix of candidates should be removed.

![screenshot](https://user-images.githubusercontent.com/10111/74592861-a3042480-5068-11ea-8fc9-b28888b10ad7.gif)
