### PR TITLE
Trigger completion when the last commit character is trigger character

### DIFF
--- a/autoload/asyncomplete/utils/_on_change/textchangedp.vim
+++ b/autoload/asyncomplete/utils/_on_change/textchangedp.vim
@@ -40,6 +40,12 @@ function! s:on_insert_leave() abort
 endfunction
 
 function! s:on_text_changed_i() abort
+    let l:ctx = asyncomplete#context()
+    let l:startcol = l:ctx['col']
+    let l:last_char = l:ctx['typed'][l:startcol - 2] " col is 1-indexed, but str 0-indexed
+    if has_key(b:asyncomplete_triggers, l:last_char)
+        let s:previous_position = getcurpos()
+    endif
     call s:maybe_notify_on_change()
 endfunction
 


### PR DESCRIPTION
Current implementation check changes of lnum with previous lnum. So if snippet was expanded, completion will not triggered.

![screenshot](https://user-images.githubusercontent.com/10111/75043456-771eee00-5503-11ea-8103-a77a0c8bd096.gif)

This change reset previous lnum when the last commed character is trigger character.

![screenshot](https://user-images.githubusercontent.com/10111/75043694-d1b84a00-5503-11ea-946b-bf5aa8e559b0.gif)
