### PR TITLE
Add suggested configuration for always-insert-newline-on-enter behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ Plug 'prabirshrestha/asyncomplete.vim'
 ```vim
 inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
 inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
-inoremap <expr> <cr>    pumvisible() ? "\<C-y>" : "\<cr>"
+inoremap <expr> <cr>    pumvisible() ? asyncomplete#close_popup() : "\<cr>"
+```
+
+If you prefer the enter key to always insert a new line (even if the popup menu is visible) then
+you can amend the above mapping as follows:
+
+```vim
+inoremap <expr> <cr> pumvisible() ? asyncomplete#close_popup() . "\<cr>" : "\<cr>"
 ```
 
 ### Force refresh completion


### PR DESCRIPTION
I wasn't sure where the docs should go but there didn't seem to be a good place already for it in the vim help so I just added it to the README.

I did also change the existing configuration suggestion to call `asyncomplete#close_popup()` just because that function returns the same key anyways but does a bit of fiddling on asyncomplete's internal state (and could conceivably change in future) so I would expect that this is a better default for people to be using.