### PR TITLE
Add setting for refresh_pattern

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -269,7 +269,7 @@ function! s:on_change() abort
     let l:ctx = asyncomplete#context()
     let l:last_char = l:ctx['typed'][l:ctx['col'] - 2] " col is 1-indexed, but str 0-indexed
     let l:triggered_sources = get(b:asyncomplete_triggers, l:last_char, {})
-    let l:refresh_pattern = get(b:, 'asyncomplete_refresh_pattern', '\(\k\+$\)')
+    let l:refresh_pattern = get(b:, 'asyncomplete_refresh_pattern', g:asyncomplete_refresh_pattern)
     let [l:_, l:startidx, l:endidx] = asyncomplete#utils#matchstrpos(l:ctx['typed'], l:refresh_pattern)
 
     for l:source_name in b:asyncomplete_active_sources

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -14,6 +14,7 @@ let g:asyncomplete_manager = get(g:, 'asyncomplete_manager', 'asyncomplete#manag
 let g:asyncomplete_change_manager = get(g:, 'asyncomplete_change_manager', ['asyncomplete#utils#_on_change#textchangedp#init', 'asyncomplete#utils#_on_change#timer#init'])
 let g:asyncomplete_triggers = get(g:, 'asyncomplete_triggers', {'*': ['.', '>', ':'] })
 let g:asyncomplete_min_chars = get(g:, 'asyncomplete_min_chars', 1)
+let g:asyncomplete_refresh_pattern = get(g:, 'asyncomplete_refresh_pattern', '\(\k\+$\)')
 
 let g:asyncomplete_auto_completeopt = get(g:, 'asyncomplete_auto_completeopt', 1)
 let g:asyncomplete_auto_popup = get(g:, 'asyncomplete_auto_popup', 1)


### PR DESCRIPTION
Hi @prabirshrestha, Thank you for the nice plugin!

This PR aims to check for multiple chars instead of just last chars.
This uses very nomagic pattern regexp.
I think that this would be compatible with the previous one.

Additionally, this can use regexp.
For example

```vim
let l:opts['triggers'] = {'*': [':', '>', '.', 'TabNine::\w\+']}
```