### PR TITLE
add support for fuzzy matching

### DIFF
--- a/doc/asyncomplete.txt
+++ b/doc/asyncomplete.txt
@@ -112,6 +112,17 @@ g:asyncomplete_min_chars                             *g:asyncomplete_min_chars*
 
     Minimum consecutive characters to trigger auto-popup. Overridden by buffer
     variable if set (`b:asyncomplete_min_chars`)
+
+g:asyncomplete_matchfuzzy                           *g:asyncomplete_matchfuzzy*
+
+    Type: |Number|
+    Default: `exists('*matchfuzzypos')`
+
+    Use |matchfuzzypos| to support fuzzy matching of 'word' when completing
+    items. Requires vim with `matchfuzzypos()` function to exists.
+
+    Set to `0` to disable fuzzy matching.
+
 ===============================================================================
 3. Functions                                            *asyncomplete-functions*
 

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -20,5 +20,6 @@ let g:asyncomplete_auto_popup = get(g:, 'asyncomplete_auto_popup', 1)
 let g:asyncomplete_popup_delay = get(g:, 'asyncomplete_popup_delay', 30)
 let g:asyncomplete_log_file = get(g:, 'asyncomplete_log_file', '')
 let g:asyncomplete_preprocessor = get(g:, 'asyncomplete_preprocessor', [])
+let g:asyncomplete_matchfuzzy = get(g:, 'asyncomplete_matchfuzzy', exists('*matchfuzzypos'))
 
 inoremap <silent> <expr> <Plug>(asyncomplete_force_refresh) asyncomplete#force_refresh()


### PR DESCRIPTION
If `g:asyncomplete_matchfuzzy` and `matchfuzzypos()` function exists, uses it for fuzzy matching.

https://asciinema.org/a/380801

![fuzzymatchasyncomplete](https://user-images.githubusercontent.com/287744/102970080-b9aab180-44ab-11eb-82a3-069a8100553b.gif)

