### PR TITLE
Fix error: "E118: Too many arguments for function: copy"

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -492,7 +492,7 @@ function! s:strip_pair_characters(base, item) abort
     if has_key(s:pair, a:base[0])
         let [l:lhs, l:rhs, l:str] = [a:base[0], s:pair[a:base[0]], l:item['word']]
         if len(l:str) > 1 && l:str[0] ==# l:lhs && l:str[-1:] ==# l:rhs
-            let l:item = copy({}, l:item)
+            let l:item = extend({}, l:item)
             let l:item['word'] = l:str[:-2]
         endif
     endif


### PR DESCRIPTION
The following error ocurred.

```text
Error detected while processing function <SNR>244_recompute_pum[44]..<SNR>244_default_preprocessor[18]..<SNR>244_strip_pair_characters:
line    7:
E118: Too many arguments for function: copy
```

I think it is `extend()`, not `copy()`.