### PR TITLE
Prevent errors from undefined s:previous_context

### DIFF
--- a/autoload/asyncomplete/utils/_on_change/textchangedp.vim
+++ b/autoload/asyncomplete/utils/_on_change/textchangedp.vim
@@ -41,7 +41,7 @@ function! s:on_insert_enter() abort
 endfunction
 
 function! s:on_insert_leave() abort
-    unlet s:previous_context
+    unlet! s:previous_context
 endfunction
 
 function! s:on_text_changed_i() abort
@@ -53,6 +53,9 @@ function! s:on_text_changed_p() abort
 endfunction
 
 function! s:maybe_notify_on_change() abort
+    if !exists('s:previous_context')
+        return
+    endif
     " We notify on_change callbacks only when the cursor position
     " has changed.
     " Unfortunatelly we need this check because in insert mode it


### PR DESCRIPTION
Prevent errors processing textchanged that don't come from insert mode.

When using asyncomplete with [vim-ripple](https://github.com/idbrii/vim-ripple), I get these errors:

    Error detected while processing TextChangedI Autocommands for "*"..function <SNR>43_on_text_changed_i[1]..<SNR>43_maybe_notify_on_change:
    line   15:
    E121: Undefined variable: s:previous_context

    Error detected while processing InsertLeave Autocommands for "*"..function <SNR>43_on_insert_leave:
    line    1:
    E108: No such variable: "s:previous_context"

ripple uses :startinsert, but I can't replicate the error with just that
command. Not sure what's wrong, but this seems like a reasonable fix.


Repro
=====
Hit CR when on a blank line:
    gvim +"RippleCreate lua"
    down arrow
    CR


Minimal vimrc:

```vim
" Invoke with:
" vim -Nu ~/.vim/reprovimrc.vim -U NONE +"RippleCreate lua"

" all plugins should work with sensible as a baseline.
let s:plugins = ['sensible']
let s:plugins += ['asyncomplete']
let s:plugins += ['ripple']

set runtimepath-=~/.vim
set runtimepath-=~/.vim/after
set runtimepath-=~/vimfiles
set runtimepath-=~/vimfiles/after
for plugin in s:plugins
    exec "set runtimepath^=~/.vim/bundle/". plugin
    exec "set runtimepath+=~/.vim/bundle/". plugin ."/after"
endfor
set viminfofile=NONE
```
