### PR TITLE
default to 0 min chars

### DIFF
--- a/doc/asyncomplete.txt
+++ b/doc/asyncomplete.txt
@@ -108,7 +108,7 @@ g:asyncomplete_preprocessor                        *g:asyncomplete_preprocessor*
 g:asyncomplete_min_chars                             *g:asyncomplete_min_chars*
 
     Type: |Number|
-    Default: 1
+    Default: 0
 
     Minimum consecutive characters to trigger auto-popup. Overridden by buffer
     variable if set (`b:asyncomplete_min_chars`)

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -13,7 +13,7 @@ endif
 let g:asyncomplete_manager = get(g:, 'asyncomplete_manager', 'asyncomplete#managers#vim#init')
 let g:asyncomplete_change_manager = get(g:, 'asyncomplete_change_manager', ['asyncomplete#utils#_on_change#textchangedp#init', 'asyncomplete#utils#_on_change#timer#init'])
 let g:asyncomplete_triggers = get(g:, 'asyncomplete_triggers', {'*': ['.', '>', ':'] })
-let g:asyncomplete_min_chars = get(g:, 'asyncomplete_min_chars', 1)
+let g:asyncomplete_min_chars = get(g:, 'asyncomplete_min_chars', 0)
 
 let g:asyncomplete_auto_completeopt = get(g:, 'asyncomplete_auto_completeopt', 1)
 let g:asyncomplete_auto_popup = get(g:, 'asyncomplete_auto_popup', 1)


### PR DESCRIPTION
Since https://github.com/prabirshrestha/asyncomplete.vim/pull/254 fixes `min_chars` we no longer show autocomplete when using trigger chars. This sets it to default min char to `0` so when user presses the trigger chars such as `.` it will show the popup.