### PR TITLE
Silence 'Not allowed to change text here' error

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -514,8 +514,11 @@ function! asyncomplete#preprocess_complete(ctx, items) abort
         setl completeopt=menuone,noinsert,noselect
     endif
 
-    call asyncomplete#log('core', 'asyncomplete#preprocess_complete calling complete()', a:ctx['startcol'], a:items)
-    call complete(a:ctx['startcol'], a:items)
+    let l:startcol = a:ctx['startcol']
+    call asyncomplete#log('core', 'asyncomplete#preprocess_complete calling complete()', l:startcol, a:items)
+    if l:startcol > 0 " Prevent E578: Not allowed to change text here
+        call complete(l:startcol, a:items)
+    endif
 endfunction
 
 function! asyncomplete#menu_selected() abort


### PR DESCRIPTION
Not sure why this happens and I haven't tried narrowing it down to a
minimal test case yet. I often get this error while typing or triggering
completion. I'd rather nothing happen than error spam, so silence it.

Example callstack caused from explicit triggering of completion:
    OmniSharp#Complete[10]
    OmniSharp#actions#complete#Get[13]
    <SNR>281_recompute_pum[44]
    <SNR>281_default_preprocessor[34]
    asyncomplete#preprocess_complete[16]
    E578: Not allowed to change text here