### PR TITLE
Add note about `<c-space>` vs. `<c-@>` to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ inoremap <expr> <cr> pumvisible() ? asyncomplete#close_popup() . "\<cr>" : "\<cr
 
 ```vim
 imap <c-space> <Plug>(asyncomplete_force_refresh)
+" For Vim 8 (<c-@> corresponds to <c-space>):
+" imap <c-@> <Plug>(asyncomplete_force_refresh)
 ```
 
 ### Auto popup


### PR DESCRIPTION
Vim 8 can't interpret `<c-space>` in the terminal properly, instead you have to write `<c-@>`.

Closes #266