### PR TITLE
ADD:  option g:asyncomplete_max_num_candidates

### DIFF
--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -515,9 +515,15 @@ function! asyncomplete#preprocess_complete(ctx, items) abort
     endif
 
     let l:startcol = a:ctx['startcol']
-    call asyncomplete#log('core', 'asyncomplete#preprocess_complete calling complete()', l:startcol, a:items)
+
+    let l:candidates = a:items
+    if  g:asyncomplete_max_num_candidates > 0 && len(a:items) > g:asyncomplete_max_num_candidates
+        l:candidates = slice(a:items)
+    endif
+
+    call asyncomplete#log('core', 'asyncomplete#preprocess_complete calling complete()', l:startcol, l:candidates)
     if l:startcol > 0 " Prevent E578: Not allowed to change text here
-        call complete(l:startcol, a:items)
+        call complete(l:startcol, l:candidates)
     endif
 endfunction
 

--- a/autoload/asyncomplete.vim
+++ b/autoload/asyncomplete.vim
@@ -518,7 +518,7 @@ function! asyncomplete#preprocess_complete(ctx, items) abort
 
     let l:candidates = a:items
     if  g:asyncomplete_max_num_candidates > 0 && len(a:items) > g:asyncomplete_max_num_candidates
-        l:candidates = slice(a:items)
+        let l:candidates = slice(a:items, 0, g:asyncomplete_max_num_candidates)
     endif
 
     call asyncomplete#log('core', 'asyncomplete#preprocess_complete calling complete()', l:startcol, l:candidates)

--- a/doc/asyncomplete.txt
+++ b/doc/asyncomplete.txt
@@ -123,6 +123,16 @@ g:asyncomplete_matchfuzzy                           *g:asyncomplete_matchfuzzy*
 
     Set to `0` to disable fuzzy matching.
 
+g:asyncomplete_max_num_candidates           *g:asyncomplete_max_num_candidates*
+
+    Type: |Number|
+    Default: 50
+
+    This option controls the maximum number of  completion suggestions shown
+    in the completion menu.
+
+    A value of 0 or less-than 0 means there is no limit.
+
 ===============================================================================
 3. Functions                                            *asyncomplete-functions*
 

--- a/doc/asyncomplete.txt
+++ b/doc/asyncomplete.txt
@@ -126,7 +126,7 @@ g:asyncomplete_matchfuzzy                           *g:asyncomplete_matchfuzzy*
 g:asyncomplete_max_num_candidates           *g:asyncomplete_max_num_candidates*
 
     Type: |Number|
-    Default: 50
+    Default: 0
 
     This option controls the maximum number of  completion suggestions shown
     in the completion menu.

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -21,6 +21,6 @@ let g:asyncomplete_popup_delay = get(g:, 'asyncomplete_popup_delay', 30)
 let g:asyncomplete_log_file = get(g:, 'asyncomplete_log_file', '')
 let g:asyncomplete_preprocessor = get(g:, 'asyncomplete_preprocessor', [])
 let g:asyncomplete_matchfuzzy = get(g:, 'asyncomplete_matchfuzzy', exists('*matchfuzzypos'))
-let g:asyncomplete_max_num_candidates = get(g:, 'asyncomplete_max_num_candidates', 50)
+let g:asyncomplete_max_num_candidates = get(g:, 'asyncomplete_max_num_candidates', 0)
 
 inoremap <silent> <expr> <Plug>(asyncomplete_force_refresh) asyncomplete#force_refresh()

--- a/plugin/asyncomplete.vim
+++ b/plugin/asyncomplete.vim
@@ -21,5 +21,6 @@ let g:asyncomplete_popup_delay = get(g:, 'asyncomplete_popup_delay', 30)
 let g:asyncomplete_log_file = get(g:, 'asyncomplete_log_file', '')
 let g:asyncomplete_preprocessor = get(g:, 'asyncomplete_preprocessor', [])
 let g:asyncomplete_matchfuzzy = get(g:, 'asyncomplete_matchfuzzy', exists('*matchfuzzypos'))
+let g:asyncomplete_max_num_candidates = get(g:, 'asyncomplete_max_num_candidates', 50)
 
 inoremap <silent> <expr> <Plug>(asyncomplete_force_refresh) asyncomplete#force_refresh()


### PR DESCRIPTION

In some case, there are a lot of matches.
1. for user,  matches are too many to select.
2. for vim, rendering many matches  affects performance

So, adding option `g:asyncomplete_max_num_candidates` to  controls the maximum number of  completion suggestions shown in the completion menu.

`g:asyncomplete_max_num_candidates` is inspired by  `g:ycm_max_num_candidates` in YouCompleteMe ( see https://github.com/ycm-core/YouCompleteMe/blob/master/doc/youcompleteme.txt for more details).


e.g.
![too-many-matches](https://user-images.githubusercontent.com/908026/193305878-4c335a1e-cb9b-44b8-a50e-c240fade4e7e.png)
